### PR TITLE
Add pre-commit and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit black flake8 mypy ruff
+      - name: Black
+        run: black --check .
+      - name: Flake8
+        run: flake8 .
+      - name: Mypy
+        run: mypy .
+      - name: Ruff
+        run: ruff check .
+      - name: Pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,27 @@
+name: Delete merged branches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            await github.rest.git.deleteRef({
+              owner,
+              repo,
+              ref: `heads/${branch}`,
+            });

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+line-length = 88
+target-version = "py311"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ pre-commit install
 Commits directly to the `main` branch are blocked by the `no-commit-to-branch` hook.
 It is recommended to enable GitHub branch protection so that changes to `main` can
 only be merged via pull requests after the CI pipeline succeeds.
+
+### Merge strategy and cleanup
+
+Configure the repository to allow only **Squash and merge** so that pull requests
+are reduced to a single commit on `main`. Enable **Automatically delete head
+branches** in repository settings to remove topic branches after a pull request
+is merged. A companion workflow, `Delete merged branches`, also cleans up merged
+branches for repositories where automatic branch deletion is not enabled.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # ML-Projects
+
 Repo to work on ML projects
+
+## Development setup
+
+This repository uses [pre-commit](https://pre-commit.com/) to run formatters and linters
+such as [Black](https://black.readthedocs.io/), [Ruff](https://github.com/astral-sh/ruff),
+[Flake8](https://flake8.pycqa.org/), and [Mypy](https://mypy.readthedocs.io/). Basic
+housekeeping hooks keep the tree spotless by trimming trailing whitespace and fixing
+missing end-of-file newlines.
+ 
+Install pre-commit and activate the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+### Branch protection
+
+Commits directly to the `main` branch are blocked by the `no-commit-to-branch` hook.
+It is recommended to enable GitHub branch protection so that changes to `main` can
+only be merged via pull requests after the CI pipeline succeeds.


### PR DESCRIPTION
## Summary
- configure pre-commit with ruff and hooks to block commits to main
- add Ruff, Black, Flake8 and Mypy checks in CI
- document development setup and branch protection expectations

## Testing
- `black --check .`
- `ruff check .`
- `mypy .`
- `flake8 .` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pip install pre-commit black flake8 mypy ruff` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6897cb36ff5483259c61c2cefd0dadc4